### PR TITLE
last one

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -78,33 +78,25 @@
 				loader(template, function(loaded) {
 					templates.cache[template] = loaded;
 
-					if (worker) {
-						launchWorker(loaded, obj, block, callback);
-					} else {
-						callback(parseTemplate(loaded));
-					}
+					parseTemplate(loaded, obj, block, callback);
 				});
 			} else {
-				if (worker) {
-					launchWorker(templates.cache[template], obj, block, callback);
-				} else {
-					callback(parseTemplate(templates.cache[template]));
-				}
+				parseTemplate(templates.cache[template], obj, block, callback);
 			}
 		} else if (callback) {
-			if (worker) {
-				launchWorker(template, obj, block, callback);
-			} else {
-				callback(parseTemplate(template));
-			}
+			parseTemplate(template, obj, block, callback);
 		} else {
-			return parseTemplate(template);
-		}
-
-		function parseTemplate(template) {
 			return parse(!block ? template : templates.getBlock(template, block), obj);
 		}
 	};
+
+	function parseTemplate(template, obj, block, callback) {
+		if (worker) {
+			launchWorker(template, obj, block, callback);
+		} else {
+			callback(parse(!block ? template : templates.getBlock(template, block), obj));
+		}
+	}
 
 	templates.registerHelper = function(name, func) {
 		helpers[name] = func;


### PR DESCRIPTION
moved backReference regex out
refactored templates.parse and parseTemplate
removed hasOwnProperty
