### PR TITLE
Template Helpers changes: parameters outside of loops and string literal parameters

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -293,7 +293,7 @@
 
 			if (fn.length) {
 				for (var j = 0, jj = fn.length; j < jj; j++) {
-					parameters.push(obj[fn[j]]);
+					parameters.push(resolveObjectValue(obj, fn[j]));
 				}
 			} else {
 				parameters = [obj];
@@ -305,6 +305,28 @@
 		}
 
 		return result;
+	}
+	
+	var literalSingleRegex = new RegExp("^'(.*)'$");
+	var literalDoubleRegex = new RegExp('^"(.*)"$');
+	
+	function indexReduction(obj,i) {
+		return obj[i];
+	}
+	
+	function resolveObjectValue(obj, parameterString) {
+		//return obj[parameterString];
+		
+		var literalMatch = literalSingleRegex.exec(parameterString);
+		if (literalMatch) return literalMatch[1];
+		literalMatch = literalDoubleRegex.exec(parameterString);
+		if (literalMatch) return literalMatch[1];
+		
+		try {
+			return parameterString.split('.').reduce(indexReduction, obj)
+		} catch (err) {
+			return undefined;
+		}
 	}
 
 	function parseObject(template, array, key, namespace) {


### PR DESCRIPTION
Trying to make two things possible:  
1.  Allow template helpers to accept values when they are used outside of an array loop.  
2.  Allow string literals to be used as arguments to template helpers.

Discussion here as well: https://community.nodebb.org/topic/9588/passing-parameters-into-template-helpers/4
